### PR TITLE
Extract internal/recap/ package from cmd/recap.go

### DIFF
--- a/cmd/factory.go
+++ b/cmd/factory.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charemma/anker/internal/sources"
 	"github.com/charemma/anker/internal/sources/claude"
@@ -27,4 +28,15 @@ func createSource(cfg sources.Config) (sources.Source, error) {
 	default:
 		return nil, fmt.Errorf("unsupported source type: %s", cfg.Type)
 	}
+}
+
+func splitTrimmed(s, sep string) []string {
+	var parts []string
+	for part := range strings.SplitSeq(s, sep) {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return parts
 }

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/charemma/anker/internal/ai"
 	"github.com/charemma/anker/internal/config"
+	"github.com/charemma/anker/internal/recap"
 	"github.com/charemma/anker/internal/sources"
-	"github.com/charemma/anker/internal/sources/git"
 	"github.com/charemma/anker/internal/storage"
 	"github.com/charemma/anker/internal/timerange"
 	"github.com/spf13/cobra"
@@ -110,80 +110,28 @@ Examples:
 		}
 
 		// Collect entries from all sources
-		var allEntries []sources.Entry
-		var gitSources []*git.GitSource
-
-		for _, cfg := range sourceConfigs {
-			source, err := createSource(cfg)
-			if err != nil {
-				fmt.Printf("Warning: %v at %s\n", err, cfg.Path)
-				continue
-			}
-
-			if recapFormat == "markdown" {
-				if gs, ok := source.(*git.GitSource); ok {
-					gitSources = append(gitSources, gs)
-				}
-			}
-
-			entries, err := source.GetEntries(tr.From, tr.To)
-			if err != nil {
-				fmt.Printf("Warning: failed to get entries from %s %s: %v\n", cfg.Type, cfg.Path, err)
-				continue
-			}
-
-			allEntries = append(allEntries, entries...)
+		result, err := recap.BuildRecap(sourceConfigs, tr, timespec, recapFormat, createSource, os.Stderr)
+		if err != nil {
+			return err
 		}
 
-		// Enrich with diffs if markdown format requested
-		if recapFormat == "markdown" {
-			for _, gitSource := range gitSources {
-				// Find entries from this git source and enrich them
-				var sourceEntries []sources.Entry
-				for _, entry := range allEntries {
-					if entry.Location == gitSource.Location() {
-						sourceEntries = append(sourceEntries, entry)
-					}
-				}
-				if err := gitSource.EnrichWithDiffs(sourceEntries); err != nil {
-					fmt.Printf("Warning: failed to enrich diffs for %s: %v\n", gitSource.Location(), err)
-				}
-				// Update entries in allEntries with enriched data
-				for i := range allEntries {
-					if allEntries[i].Location == gitSource.Location() {
-						for _, enriched := range sourceEntries {
-							if allEntries[i].Metadata["hash"] == enriched.Metadata["hash"] {
-								allEntries[i] = enriched
-								break
-							}
-						}
-					}
-				}
-			}
-		}
-
-		if len(allEntries) == 0 {
+		if len(result.Entries) == 0 {
 			fmt.Printf("No activity found for %s\n", timespec)
 			return nil
 		}
 
-		// Sort entries by timestamp (newest first)
-		sort.Slice(allEntries, func(i, j int) bool {
-			return allEntries[i].Timestamp.After(allEntries[j].Timestamp)
-		})
-
 		// Generate report based on format
 		switch recapFormat {
 		case "simple":
-			return printSimpleRecap(allEntries, tr, timespec)
+			return printSimpleRecap(result.Entries, tr, timespec)
 		case "detailed":
-			return printDetailedRecap(os.Stdout, allEntries, tr, timespec)
+			return printDetailedRecap(os.Stdout, result.Entries, tr, timespec)
 		case "json":
-			return printJSONRecap(allEntries, tr, timespec)
+			return printJSONRecap(result.Entries, tr, timespec)
 		case "markdown":
-			return printMarkdownRecap(allEntries, tr, timespec)
+			return printMarkdownRecap(result.Entries, tr, timespec)
 		case "ai":
-			return printAIRecap(cfg, allEntries, tr, timespec)
+			return printAIRecap(cfg, result.Entries, tr, timespec)
 		default:
 			return fmt.Errorf("unknown format: %s", recapFormat)
 		}
@@ -447,17 +395,6 @@ func printMarkdownRecap(allEntries []sources.Entry, tr *timerange.TimeRange, tim
 	}
 
 	return nil
-}
-
-func splitTrimmed(s, sep string) []string {
-	var parts []string
-	for part := range strings.SplitSeq(s, sep) {
-		trimmed := strings.TrimSpace(part)
-		if trimmed != "" {
-			parts = append(parts, trimmed)
-		}
-	}
-	return parts
 }
 
 func init() {

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -14,17 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultAIPrompt = `Summarize my workday based on the activity log below.
-Start with the period as a heading (e.g. "# Recap: 2026-02-23 to 2026-03-01").
-Group by topic or theme, not chronologically.
-Keep it concise -- a few bullet points per topic.
-Skip trivial entries (typo fixes, formatting, etc.) unless they are part of a larger change.
-For each topic, also highlight:
-- Decisions made and why (e.g. chose X over Y because...)
-- Key insights or lessons learned
-- Open threads or unfinished business
-Only include these if they are actually present in the data -- don't invent them.`
-
 var (
 	recapFormat string
 	recapPrompt string
@@ -117,53 +106,24 @@ Examples:
 
 		// AI format uses detailed rendering as input, then transforms via LLM
 		if recapFormat == "ai" {
-			return printAIRecap(cfg, result, tr, timespec)
+			var buf bytes.Buffer
+			if err := recap.RenderDetailed(&buf, result); err != nil {
+				return fmt.Errorf("failed to render recap: %w", err)
+			}
+
+			period := fmt.Sprintf("%s (%s to %s)", timespec, tr.From.Format("2006-01-02"), tr.To.Format("2006-01-02"))
+			return ai.Transform(context.Background(), os.Stdout, buf.String(), period, ai.TransformConfig{
+				AIPrompt:     cfg.AIPrompt,
+				AIBackend:    cfg.AIBackend,
+				AICLICommand: cfg.AICLICommand,
+				AIBaseURL:    cfg.AIBaseURL,
+				AIModel:      cfg.AIModel,
+				AIAPIKey:     cfg.AIAPIKey,
+			}, recapPrompt, recapAPIKey)
 		}
 
 		return recap.Render(os.Stdout, result, recapFormat)
 	},
-}
-
-func printAIRecap(cfg *config.Config, result *recap.RecapResult, tr *timerange.TimeRange, timespec string) error {
-	// Render detailed output to a string
-	var buf bytes.Buffer
-	if err := recap.RenderDetailed(&buf, result); err != nil {
-		return fmt.Errorf("failed to render recap: %w", err)
-	}
-
-	// Resolve prompt: --prompt flag > config > default
-	prompt := defaultAIPrompt
-	if cfg.AIPrompt != "" {
-		prompt = cfg.AIPrompt
-	}
-	if recapPrompt != "" {
-		prompt = recapPrompt
-	}
-
-	// Inject time range context
-	period := fmt.Sprintf("%s to %s", tr.From.Format("2006-01-02"), tr.To.Format("2006-01-02"))
-	prompt = fmt.Sprintf("Period: %s (%s)\n\n%s", timespec, period, prompt)
-
-	if cfg.AIBackend == "cli" {
-		return ai.RunCLI(cfg.AICLICommand, prompt, buf.String(), os.Stdout)
-	}
-
-	// Resolve API key: --api-key flag > AI_API_KEY env > config
-	apiKey := cfg.AIAPIKey
-	if envKey := os.Getenv("AI_API_KEY"); envKey != "" {
-		apiKey = envKey
-	}
-	if recapAPIKey != "" {
-		apiKey = recapAPIKey
-	}
-
-	client := &ai.Client{
-		BaseURL: cfg.AIBaseURL,
-		APIKey:  apiKey,
-		Model:   cfg.AIModel,
-	}
-
-	return client.StreamCompletion(context.Background(), prompt, buf.String(), os.Stdout)
 }
 
 func init() {

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -3,17 +3,12 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"os"
-	"sort"
-	"strings"
 
 	"github.com/charemma/anker/internal/ai"
 	"github.com/charemma/anker/internal/config"
 	"github.com/charemma/anker/internal/recap"
-	"github.com/charemma/anker/internal/sources"
 	"github.com/charemma/anker/internal/storage"
 	"github.com/charemma/anker/internal/timerange"
 	"github.com/spf13/cobra"
@@ -120,150 +115,19 @@ Examples:
 			return nil
 		}
 
-		// Generate report based on format
-		switch recapFormat {
-		case "simple":
-			return printSimpleRecap(result.Entries, tr, timespec)
-		case "detailed":
-			return printDetailedRecap(os.Stdout, result.Entries, tr, timespec)
-		case "json":
-			return printJSONRecap(result.Entries, tr, timespec)
-		case "markdown":
-			return printMarkdownRecap(result.Entries, tr, timespec)
-		case "ai":
-			return printAIRecap(cfg, result.Entries, tr, timespec)
-		default:
-			return fmt.Errorf("unknown format: %s", recapFormat)
+		// AI format uses detailed rendering as input, then transforms via LLM
+		if recapFormat == "ai" {
+			return printAIRecap(cfg, result, tr, timespec)
 		}
+
+		return recap.Render(os.Stdout, result, recapFormat)
 	},
 }
 
-func printSimpleRecap(allEntries []sources.Entry, tr *timerange.TimeRange, timespec string) error {
-	fmt.Printf("\n")
-	fmt.Printf("Work Recap\n")
-	fmt.Printf("==========\n")
-	fmt.Printf("Period: %s - %s\n", tr.From.Format("02 Jan 2006"), tr.To.Format("02 Jan 2006"))
-	fmt.Printf("Total: %d activities\n\n", len(allEntries))
-
-	// Group by repository/source location
-	byRepo := make(map[string][]sources.Entry)
-	for _, entry := range allEntries {
-		byRepo[entry.Location] = append(byRepo[entry.Location], entry)
-	}
-
-	// Get sorted repo names
-	repos := make([]string, 0, len(byRepo))
-	for repo := range byRepo {
-		repos = append(repos, repo)
-	}
-	sort.Strings(repos)
-
-	// Print entries grouped by repository
-	for _, repoPath := range repos {
-		entries := byRepo[repoPath]
-		repoName := repoPath
-		if idx := strings.LastIndex(repoName, "/"); idx != -1 {
-			repoName = repoName[idx+1:]
-		}
-
-		// Determine source type and format header
-		if len(entries) > 0 {
-			switch entries[0].Source {
-			case "obsidian":
-				fmt.Printf("Obsidian Vault\n")
-				fmt.Printf("%s\n\n", repoName)
-			case "git":
-				fmt.Printf("Git Repository: %s\n", repoName)
-				fmt.Printf("(%s)\n\n", repoPath)
-			case "markdown":
-				fmt.Printf("Markdown Notes: %s\n", repoName)
-				fmt.Printf("(%s)\n\n", repoPath)
-			case "claude":
-				fmt.Printf("Claude Sessions: %s\n", repoName)
-				fmt.Printf("(%s)\n\n", repoPath)
-			default:
-				fmt.Printf("%s\n\n", repoName)
-			}
-		}
-
-		for _, entry := range entries {
-			fmt.Printf("  • %s\n", entry.Content)
-		}
-		fmt.Println()
-	}
-
-	return nil
-}
-
-func printDetailedRecap(w io.Writer, allEntries []sources.Entry, tr *timerange.TimeRange, timespec string) error {
-	_, _ = fmt.Fprint(w, "\n")
-	_, _ = fmt.Fprint(w, "Work Recap (Detailed)\n")
-	_, _ = fmt.Fprint(w, "=====================\n")
-	_, _ = fmt.Fprintf(w, "Period: %s - %s\n", tr.From.Format("02 Jan 2006"), tr.To.Format("02 Jan 2006"))
-	_, _ = fmt.Fprintf(w, "Total: %d activities\n\n", len(allEntries))
-
-	// Group by repository
-	byRepo := make(map[string][]sources.Entry)
-	for _, entry := range allEntries {
-		byRepo[entry.Location] = append(byRepo[entry.Location], entry)
-	}
-
-	repos := make([]string, 0, len(byRepo))
-	for repo := range byRepo {
-		repos = append(repos, repo)
-	}
-	sort.Strings(repos)
-
-	for _, repoPath := range repos {
-		entries := byRepo[repoPath]
-		repoName := repoPath
-		if idx := strings.LastIndex(repoName, "/"); idx != -1 {
-			repoName = repoName[idx+1:]
-		}
-
-		// Determine source type and format header
-		if len(entries) > 0 {
-			switch entries[0].Source {
-			case "obsidian":
-				_, _ = fmt.Fprintf(w, "Obsidian Vault\n")
-				_, _ = fmt.Fprintf(w, "%s\n\n", repoName)
-			case "git":
-				_, _ = fmt.Fprintf(w, "Git Repository: %s\n", repoName)
-				_, _ = fmt.Fprintf(w, "(%s)\n\n", repoPath)
-			case "markdown":
-				_, _ = fmt.Fprintf(w, "Markdown Notes: %s\n", repoName)
-				_, _ = fmt.Fprintf(w, "(%s)\n\n", repoPath)
-			case "claude":
-				_, _ = fmt.Fprintf(w, "Claude Sessions: %s\n", repoName)
-				_, _ = fmt.Fprintf(w, "(%s)\n\n", repoPath)
-			default:
-				_, _ = fmt.Fprintf(w, "%s\n\n", repoName)
-			}
-		}
-
-		for _, entry := range entries {
-			_, _ = fmt.Fprintf(w, "  %s\n", entry.Timestamp.Format("Mon Jan 2, 15:04"))
-			_, _ = fmt.Fprintf(w, "  %s\n", entry.Content)
-			if author, ok := entry.Metadata["author"]; ok {
-				_, _ = fmt.Fprintf(w, "  Author: %s\n", author)
-			}
-			if hash, ok := entry.Metadata["hash"]; ok {
-				_, _ = fmt.Fprintf(w, "  Commit: %s\n", hash[:8])
-			}
-			if slug, ok := entry.Metadata["slug"]; ok {
-				_, _ = fmt.Fprintf(w, "  Session: %s\n", slug)
-			}
-			_, _ = fmt.Fprintln(w)
-		}
-	}
-
-	return nil
-}
-
-func printAIRecap(cfg *config.Config, allEntries []sources.Entry, tr *timerange.TimeRange, timespec string) error {
+func printAIRecap(cfg *config.Config, result *recap.RecapResult, tr *timerange.TimeRange, timespec string) error {
 	// Render detailed output to a string
 	var buf bytes.Buffer
-	if err := printDetailedRecap(&buf, allEntries, tr, timespec); err != nil {
+	if err := recap.RenderDetailed(&buf, result); err != nil {
 		return fmt.Errorf("failed to render recap: %w", err)
 	}
 
@@ -300,101 +164,6 @@ func printAIRecap(cfg *config.Config, allEntries []sources.Entry, tr *timerange.
 	}
 
 	return client.StreamCompletion(context.Background(), prompt, buf.String(), os.Stdout)
-}
-
-func printJSONRecap(allEntries []sources.Entry, tr *timerange.TimeRange, timespec string) error {
-	type JSONReport struct {
-		Period struct {
-			From string `json:"from"`
-			To   string `json:"to"`
-		} `json:"period"`
-		Total      int             `json:"total"`
-		Activities []sources.Entry `json:"activities"`
-	}
-
-	report := JSONReport{
-		Total:      len(allEntries),
-		Activities: allEntries,
-	}
-	report.Period.From = tr.From.Format("2006-01-02")
-	report.Period.To = tr.To.Format("2006-01-02")
-
-	encoder := json.NewEncoder(os.Stdout)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(report)
-}
-
-func printMarkdownRecap(allEntries []sources.Entry, tr *timerange.TimeRange, timespec string) error {
-	fmt.Printf("# Work Recap\n\n")
-	fmt.Printf("**Period:** %s to %s\n", tr.From.Format("2006-01-02"), tr.To.Format("2006-01-02"))
-	fmt.Printf("**Total Activities:** %d\n\n", len(allEntries))
-	fmt.Printf("---\n\n")
-	fmt.Printf("This recap contains git commits with full diffs for the specified period.\n")
-	fmt.Printf("Each commit includes the message and the complete code changes.\n\n")
-
-	// Group by repository
-	byRepo := make(map[string][]sources.Entry)
-	for _, entry := range allEntries {
-		byRepo[entry.Location] = append(byRepo[entry.Location], entry)
-	}
-
-	repos := make([]string, 0, len(byRepo))
-	for repo := range byRepo {
-		repos = append(repos, repo)
-	}
-	sort.Strings(repos)
-
-	for _, repoPath := range repos {
-		entries := byRepo[repoPath]
-		repoName := repoPath
-		if idx := strings.LastIndex(repoName, "/"); idx != -1 {
-			repoName = repoName[idx+1:]
-		}
-
-		// Determine source type and format header
-		if len(entries) > 0 {
-			switch entries[0].Source {
-			case "obsidian":
-				fmt.Printf("## Obsidian Vault\n\n")
-				fmt.Printf("**%s**\n\n", repoName)
-				fmt.Printf("`%s`\n\n", repoPath)
-			case "git":
-				fmt.Printf("## Git Repository: %s\n\n", repoName)
-				fmt.Printf("`%s`\n\n", repoPath)
-			case "markdown":
-				fmt.Printf("## Markdown Notes: %s\n\n", repoName)
-				fmt.Printf("`%s`\n\n", repoPath)
-			case "claude":
-				fmt.Printf("## Claude Sessions: %s\n\n", repoName)
-				fmt.Printf("`%s`\n\n", repoPath)
-			default:
-				fmt.Printf("## %s\n\n", repoName)
-				fmt.Printf("`%s`\n\n", repoPath)
-			}
-		}
-
-		for i, entry := range entries {
-			fmt.Printf("### %d.\n\n", i+1)
-			fmt.Printf("**Date:** %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"))
-			if author, ok := entry.Metadata["author"]; ok {
-				fmt.Printf("**Author:** %s\n", author)
-			}
-			if hash, ok := entry.Metadata["hash"]; ok {
-				fmt.Printf("**Hash:** `%s`\n", hash)
-			}
-			fmt.Printf("**Message:** %s\n\n", entry.Content)
-
-			if diff, ok := entry.Metadata["diff"]; ok && diff != "" {
-				fmt.Printf("**Changes:**\n\n```diff\n%s\n```\n\n", diff)
-			} else {
-				fmt.Printf("*(No diff available)*\n\n")
-			}
-
-			fmt.Printf("---\n\n")
-		}
-	}
-
-	return nil
 }
 
 func init() {

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -83,7 +83,11 @@ Examples:
 		}
 
 		if len(sourceConfigs) == 0 {
-			fmt.Println("No sources configured. Use 'anker source add' to get started.")
+			fmt.Println("No sources configured yet.")
+			fmt.Println()
+			fmt.Println("Quick setup options:")
+			fmt.Println("  anker source add        Add the current directory")
+			fmt.Println("  anker source add ~/code Add a directory of repos")
 			return nil
 		}
 

--- a/internal/ai/transform.go
+++ b/internal/ai/transform.go
@@ -1,0 +1,68 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+)
+
+const defaultPrompt = `Summarize my workday based on the activity log below.
+Start with the period as a heading (e.g. "# Recap: 2026-02-23 to 2026-03-01").
+Group by topic or theme, not chronologically.
+Keep it concise -- a few bullet points per topic.
+Skip trivial entries (typo fixes, formatting, etc.) unless they are part of a larger change.
+For each topic, also highlight:
+- Decisions made and why (e.g. chose X over Y because...)
+- Key insights or lessons learned
+- Open threads or unfinished business
+Only include these if they are actually present in the data -- don't invent them.`
+
+// TransformConfig holds the AI-related fields needed by Transform.
+// This avoids importing the config package directly.
+type TransformConfig struct {
+	AIPrompt     string
+	AIBackend    string
+	AICLICommand string
+	AIBaseURL    string
+	AIModel      string
+	AIAPIKey     string
+}
+
+// Transform sends rendered recap text through an AI backend for summarization.
+// It resolves the prompt (promptOverride > config > default) and API key
+// (apiKeyOverride > AI_API_KEY env > config), then dispatches to CLI or API.
+func Transform(ctx context.Context, w io.Writer, renderedText string, period string, cfg TransformConfig, promptOverride, apiKeyOverride string) error {
+	// Resolve prompt: override > config > default
+	prompt := defaultPrompt
+	if cfg.AIPrompt != "" {
+		prompt = cfg.AIPrompt
+	}
+	if promptOverride != "" {
+		prompt = promptOverride
+	}
+
+	// Inject time range context
+	prompt = fmt.Sprintf("Period: %s\n\n%s", period, prompt)
+
+	if cfg.AIBackend == "cli" {
+		return RunCLI(cfg.AICLICommand, prompt, renderedText, w)
+	}
+
+	// Resolve API key: override > env > config
+	apiKey := cfg.AIAPIKey
+	if envKey := os.Getenv("AI_API_KEY"); envKey != "" {
+		apiKey = envKey
+	}
+	if apiKeyOverride != "" {
+		apiKey = apiKeyOverride
+	}
+
+	client := &Client{
+		BaseURL: cfg.AIBaseURL,
+		APIKey:  apiKey,
+		Model:   cfg.AIModel,
+	}
+
+	return client.StreamCompletion(ctx, prompt, renderedText, w)
+}

--- a/internal/recap/collect.go
+++ b/internal/recap/collect.go
@@ -23,13 +23,13 @@ func BuildRecap(sourceConfigs []sources.Config, tr *timerange.TimeRange, timespe
 	for _, cfg := range sourceConfigs {
 		source, err := factory(cfg)
 		if err != nil {
-			fmt.Fprintf(warn, "Warning: %v at %s\n", err, cfg.Path)
+			_, _ = fmt.Fprintf(warn, "Warning: %v at %s\n", err, cfg.Path)
 			continue
 		}
 
 		entries, err := source.GetEntries(tr.From, tr.To)
 		if err != nil {
-			fmt.Fprintf(warn, "Warning: failed to get entries from %s %s: %v\n", cfg.Type, cfg.Path, err)
+			_, _ = fmt.Fprintf(warn, "Warning: failed to get entries from %s %s: %v\n", cfg.Type, cfg.Path, err)
 			continue
 		}
 
@@ -37,7 +37,7 @@ func BuildRecap(sourceConfigs []sources.Config, tr *timerange.TimeRange, timespe
 		if format == "markdown" {
 			if gs, ok := source.(*git.GitSource); ok {
 				if err := gs.EnrichWithDiffs(entries); err != nil {
-					fmt.Fprintf(warn, "Warning: failed to enrich diffs for %s: %v\n", gs.Location(), err)
+					_, _ = fmt.Fprintf(warn, "Warning: failed to enrich diffs for %s: %v\n", gs.Location(), err)
 				}
 			}
 		}

--- a/internal/recap/collect.go
+++ b/internal/recap/collect.go
@@ -1,0 +1,58 @@
+package recap
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/charemma/anker/internal/sources"
+	"github.com/charemma/anker/internal/sources/git"
+	"github.com/charemma/anker/internal/timerange"
+)
+
+// SourceFactory creates a Source from a stored Config.
+// Injected by the command layer to avoid a circular dependency on cmd/.
+type SourceFactory func(sources.Config) (sources.Source, error)
+
+// BuildRecap collects entries from all configured sources for the given time
+// range. When format is "markdown", git sources are enriched with diffs.
+// Warnings about individual source failures are written to warn.
+func BuildRecap(sourceConfigs []sources.Config, tr *timerange.TimeRange, timespec string, format string, factory SourceFactory, warn io.Writer) (*RecapResult, error) {
+	var allEntries []sources.Entry
+
+	for _, cfg := range sourceConfigs {
+		source, err := factory(cfg)
+		if err != nil {
+			fmt.Fprintf(warn, "Warning: %v at %s\n", err, cfg.Path)
+			continue
+		}
+
+		entries, err := source.GetEntries(tr.From, tr.To)
+		if err != nil {
+			fmt.Fprintf(warn, "Warning: failed to get entries from %s %s: %v\n", cfg.Type, cfg.Path, err)
+			continue
+		}
+
+		// Enrich git entries with diffs when markdown format is requested
+		if format == "markdown" {
+			if gs, ok := source.(*git.GitSource); ok {
+				if err := gs.EnrichWithDiffs(entries); err != nil {
+					fmt.Fprintf(warn, "Warning: failed to enrich diffs for %s: %v\n", gs.Location(), err)
+				}
+			}
+		}
+
+		allEntries = append(allEntries, entries...)
+	}
+
+	// Sort entries by timestamp (newest first)
+	sort.Slice(allEntries, func(i, j int) bool {
+		return allEntries[i].Timestamp.After(allEntries[j].Timestamp)
+	})
+
+	return &RecapResult{
+		TimeRange: tr,
+		Timespec:  timespec,
+		Entries:   allEntries,
+	}, nil
+}

--- a/internal/recap/group.go
+++ b/internal/recap/group.go
@@ -1,0 +1,75 @@
+package recap
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/charemma/anker/internal/sources"
+)
+
+// RepoGroup represents entries from a single source location, with
+// pre-computed display name and source type for rendering.
+type RepoGroup struct {
+	Path    string
+	Name    string
+	Source  string
+	Entries []sources.Entry
+}
+
+// GroupByRepo groups entries by location, extracts display names,
+// and returns groups sorted alphabetically by path.
+func GroupByRepo(entries []sources.Entry) []RepoGroup {
+	byRepo := make(map[string][]sources.Entry)
+	for _, entry := range entries {
+		byRepo[entry.Location] = append(byRepo[entry.Location], entry)
+	}
+
+	paths := make([]string, 0, len(byRepo))
+	for path := range byRepo {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	groups := make([]RepoGroup, 0, len(paths))
+	for _, path := range paths {
+		repoEntries := byRepo[path]
+		name := path
+		if idx := strings.LastIndex(name, "/"); idx != -1 {
+			name = name[idx+1:]
+		}
+
+		source := ""
+		if len(repoEntries) > 0 {
+			source = repoEntries[0].Source
+		}
+
+		groups = append(groups, RepoGroup{
+			Path:    path,
+			Name:    name,
+			Source:  source,
+			Entries: repoEntries,
+		})
+	}
+
+	return groups
+}
+
+// SourceLabel returns a human-readable label for a source type.
+// For unknown types, returns the type name with a capitalized first letter.
+func SourceLabel(sourceType string) string {
+	switch sourceType {
+	case "git":
+		return "Git Repository"
+	case "obsidian":
+		return "Obsidian Vault"
+	case "markdown":
+		return "Markdown Notes"
+	case "claude":
+		return "Claude Sessions"
+	default:
+		if sourceType == "" {
+			return ""
+		}
+		return strings.ToUpper(sourceType[:1]) + sourceType[1:]
+	}
+}

--- a/internal/recap/render.go
+++ b/internal/recap/render.go
@@ -1,0 +1,22 @@
+package recap
+
+import (
+	"fmt"
+	"io"
+)
+
+// Render dispatches to the appropriate renderer based on format string.
+func Render(w io.Writer, result *RecapResult, format string) error {
+	switch format {
+	case "simple":
+		return RenderSimple(w, result)
+	case "detailed":
+		return RenderDetailed(w, result)
+	case "json":
+		return RenderJSON(w, result)
+	case "markdown":
+		return RenderMarkdown(w, result)
+	default:
+		return fmt.Errorf("unknown format: %s", format)
+	}
+}

--- a/internal/recap/render_detailed.go
+++ b/internal/recap/render_detailed.go
@@ -1,0 +1,51 @@
+package recap
+
+import (
+	"fmt"
+	"io"
+)
+
+// RenderDetailed writes a recap with timestamps, authors, and commit hashes.
+func RenderDetailed(w io.Writer, result *RecapResult) error {
+	_, _ = fmt.Fprint(w, "\n")
+	_, _ = fmt.Fprint(w, "Work Recap (Detailed)\n")
+	_, _ = fmt.Fprint(w, "=====================\n")
+	_, _ = fmt.Fprintf(w, "Period: %s - %s\n", result.TimeRange.From.Format("02 Jan 2006"), result.TimeRange.To.Format("02 Jan 2006"))
+	_, _ = fmt.Fprintf(w, "Total: %d activities\n\n", len(result.Entries))
+
+	for _, group := range GroupByRepo(result.Entries) {
+		switch group.Source {
+		case "obsidian":
+			_, _ = fmt.Fprintf(w, "Obsidian Vault\n")
+			_, _ = fmt.Fprintf(w, "%s\n\n", group.Name)
+		case "git":
+			_, _ = fmt.Fprintf(w, "Git Repository: %s\n", group.Name)
+			_, _ = fmt.Fprintf(w, "(%s)\n\n", group.Path)
+		case "markdown":
+			_, _ = fmt.Fprintf(w, "Markdown Notes: %s\n", group.Name)
+			_, _ = fmt.Fprintf(w, "(%s)\n\n", group.Path)
+		case "claude":
+			_, _ = fmt.Fprintf(w, "Claude Sessions: %s\n", group.Name)
+			_, _ = fmt.Fprintf(w, "(%s)\n\n", group.Path)
+		default:
+			_, _ = fmt.Fprintf(w, "%s\n\n", group.Name)
+		}
+
+		for _, entry := range group.Entries {
+			_, _ = fmt.Fprintf(w, "  %s\n", entry.Timestamp.Format("Mon Jan 2, 15:04"))
+			_, _ = fmt.Fprintf(w, "  %s\n", entry.Content)
+			if author, ok := entry.Metadata["author"]; ok {
+				_, _ = fmt.Fprintf(w, "  Author: %s\n", author)
+			}
+			if hash, ok := entry.Metadata["hash"]; ok {
+				_, _ = fmt.Fprintf(w, "  Commit: %s\n", hash[:8])
+			}
+			if slug, ok := entry.Metadata["slug"]; ok {
+				_, _ = fmt.Fprintf(w, "  Session: %s\n", slug)
+			}
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+
+	return nil
+}

--- a/internal/recap/render_json.go
+++ b/internal/recap/render_json.go
@@ -1,0 +1,31 @@
+package recap
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/charemma/anker/internal/sources"
+)
+
+// RenderJSON writes the recap as structured JSON.
+func RenderJSON(w io.Writer, result *RecapResult) error {
+	type JSONReport struct {
+		Period struct {
+			From string `json:"from"`
+			To   string `json:"to"`
+		} `json:"period"`
+		Total      int             `json:"total"`
+		Activities []sources.Entry `json:"activities"`
+	}
+
+	report := JSONReport{
+		Total:      len(result.Entries),
+		Activities: result.Entries,
+	}
+	report.Period.From = result.TimeRange.From.Format("2006-01-02")
+	report.Period.To = result.TimeRange.To.Format("2006-01-02")
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}

--- a/internal/recap/render_markdown.go
+++ b/internal/recap/render_markdown.go
@@ -7,51 +7,51 @@ import (
 
 // RenderMarkdown writes a full markdown recap with diffs.
 func RenderMarkdown(w io.Writer, result *RecapResult) error {
-	fmt.Fprintf(w, "# Work Recap\n\n")
-	fmt.Fprintf(w, "**Period:** %s to %s\n", result.TimeRange.From.Format("2006-01-02"), result.TimeRange.To.Format("2006-01-02"))
-	fmt.Fprintf(w, "**Total Activities:** %d\n\n", len(result.Entries))
-	fmt.Fprintf(w, "---\n\n")
-	fmt.Fprintf(w, "This recap contains git commits with full diffs for the specified period.\n")
-	fmt.Fprintf(w, "Each commit includes the message and the complete code changes.\n\n")
+	_, _ = fmt.Fprintf(w, "# Work Recap\n\n")
+	_, _ = fmt.Fprintf(w, "**Period:** %s to %s\n", result.TimeRange.From.Format("2006-01-02"), result.TimeRange.To.Format("2006-01-02"))
+	_, _ = fmt.Fprintf(w, "**Total Activities:** %d\n\n", len(result.Entries))
+	_, _ = fmt.Fprintf(w, "---\n\n")
+	_, _ = fmt.Fprintf(w, "This recap contains git commits with full diffs for the specified period.\n")
+	_, _ = fmt.Fprintf(w, "Each commit includes the message and the complete code changes.\n\n")
 
 	for _, group := range GroupByRepo(result.Entries) {
 		switch group.Source {
 		case "obsidian":
-			fmt.Fprintf(w, "## Obsidian Vault\n\n")
-			fmt.Fprintf(w, "**%s**\n\n", group.Name)
-			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+			_, _ = fmt.Fprintf(w, "## Obsidian Vault\n\n")
+			_, _ = fmt.Fprintf(w, "**%s**\n\n", group.Name)
+			_, _ = fmt.Fprintf(w, "`%s`\n\n", group.Path)
 		case "git":
-			fmt.Fprintf(w, "## Git Repository: %s\n\n", group.Name)
-			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+			_, _ = fmt.Fprintf(w, "## Git Repository: %s\n\n", group.Name)
+			_, _ = fmt.Fprintf(w, "`%s`\n\n", group.Path)
 		case "markdown":
-			fmt.Fprintf(w, "## Markdown Notes: %s\n\n", group.Name)
-			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+			_, _ = fmt.Fprintf(w, "## Markdown Notes: %s\n\n", group.Name)
+			_, _ = fmt.Fprintf(w, "`%s`\n\n", group.Path)
 		case "claude":
-			fmt.Fprintf(w, "## Claude Sessions: %s\n\n", group.Name)
-			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+			_, _ = fmt.Fprintf(w, "## Claude Sessions: %s\n\n", group.Name)
+			_, _ = fmt.Fprintf(w, "`%s`\n\n", group.Path)
 		default:
-			fmt.Fprintf(w, "## %s\n\n", group.Name)
-			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+			_, _ = fmt.Fprintf(w, "## %s\n\n", group.Name)
+			_, _ = fmt.Fprintf(w, "`%s`\n\n", group.Path)
 		}
 
 		for i, entry := range group.Entries {
-			fmt.Fprintf(w, "### %d.\n\n", i+1)
-			fmt.Fprintf(w, "**Date:** %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"))
+			_, _ = fmt.Fprintf(w, "### %d.\n\n", i+1)
+			_, _ = fmt.Fprintf(w, "**Date:** %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"))
 			if author, ok := entry.Metadata["author"]; ok {
-				fmt.Fprintf(w, "**Author:** %s\n", author)
+				_, _ = fmt.Fprintf(w, "**Author:** %s\n", author)
 			}
 			if hash, ok := entry.Metadata["hash"]; ok {
-				fmt.Fprintf(w, "**Hash:** `%s`\n", hash)
+				_, _ = fmt.Fprintf(w, "**Hash:** `%s`\n", hash)
 			}
-			fmt.Fprintf(w, "**Message:** %s\n\n", entry.Content)
+			_, _ = fmt.Fprintf(w, "**Message:** %s\n\n", entry.Content)
 
 			if diff, ok := entry.Metadata["diff"]; ok && diff != "" {
-				fmt.Fprintf(w, "**Changes:**\n\n```diff\n%s\n```\n\n", diff)
+				_, _ = fmt.Fprintf(w, "**Changes:**\n\n```diff\n%s\n```\n\n", diff)
 			} else {
-				fmt.Fprintf(w, "*(No diff available)*\n\n")
+				_, _ = fmt.Fprintf(w, "*(No diff available)*\n\n")
 			}
 
-			fmt.Fprintf(w, "---\n\n")
+			_, _ = fmt.Fprintf(w, "---\n\n")
 		}
 	}
 

--- a/internal/recap/render_markdown.go
+++ b/internal/recap/render_markdown.go
@@ -1,0 +1,59 @@
+package recap
+
+import (
+	"fmt"
+	"io"
+)
+
+// RenderMarkdown writes a full markdown recap with diffs.
+func RenderMarkdown(w io.Writer, result *RecapResult) error {
+	fmt.Fprintf(w, "# Work Recap\n\n")
+	fmt.Fprintf(w, "**Period:** %s to %s\n", result.TimeRange.From.Format("2006-01-02"), result.TimeRange.To.Format("2006-01-02"))
+	fmt.Fprintf(w, "**Total Activities:** %d\n\n", len(result.Entries))
+	fmt.Fprintf(w, "---\n\n")
+	fmt.Fprintf(w, "This recap contains git commits with full diffs for the specified period.\n")
+	fmt.Fprintf(w, "Each commit includes the message and the complete code changes.\n\n")
+
+	for _, group := range GroupByRepo(result.Entries) {
+		switch group.Source {
+		case "obsidian":
+			fmt.Fprintf(w, "## Obsidian Vault\n\n")
+			fmt.Fprintf(w, "**%s**\n\n", group.Name)
+			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+		case "git":
+			fmt.Fprintf(w, "## Git Repository: %s\n\n", group.Name)
+			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+		case "markdown":
+			fmt.Fprintf(w, "## Markdown Notes: %s\n\n", group.Name)
+			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+		case "claude":
+			fmt.Fprintf(w, "## Claude Sessions: %s\n\n", group.Name)
+			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+		default:
+			fmt.Fprintf(w, "## %s\n\n", group.Name)
+			fmt.Fprintf(w, "`%s`\n\n", group.Path)
+		}
+
+		for i, entry := range group.Entries {
+			fmt.Fprintf(w, "### %d.\n\n", i+1)
+			fmt.Fprintf(w, "**Date:** %s\n", entry.Timestamp.Format("2006-01-02 15:04:05"))
+			if author, ok := entry.Metadata["author"]; ok {
+				fmt.Fprintf(w, "**Author:** %s\n", author)
+			}
+			if hash, ok := entry.Metadata["hash"]; ok {
+				fmt.Fprintf(w, "**Hash:** `%s`\n", hash)
+			}
+			fmt.Fprintf(w, "**Message:** %s\n\n", entry.Content)
+
+			if diff, ok := entry.Metadata["diff"]; ok && diff != "" {
+				fmt.Fprintf(w, "**Changes:**\n\n```diff\n%s\n```\n\n", diff)
+			} else {
+				fmt.Fprintf(w, "*(No diff available)*\n\n")
+			}
+
+			fmt.Fprintf(w, "---\n\n")
+		}
+	}
+
+	return nil
+}

--- a/internal/recap/render_simple.go
+++ b/internal/recap/render_simple.go
@@ -7,34 +7,34 @@ import (
 
 // RenderSimple writes a compact recap with commit messages only.
 func RenderSimple(w io.Writer, result *RecapResult) error {
-	fmt.Fprintf(w, "\n")
-	fmt.Fprintf(w, "Work Recap\n")
-	fmt.Fprintf(w, "==========\n")
-	fmt.Fprintf(w, "Period: %s - %s\n", result.TimeRange.From.Format("02 Jan 2006"), result.TimeRange.To.Format("02 Jan 2006"))
-	fmt.Fprintf(w, "Total: %d activities\n\n", len(result.Entries))
+	_, _ = fmt.Fprintf(w, "\n")
+	_, _ = fmt.Fprintf(w, "Work Recap\n")
+	_, _ = fmt.Fprintf(w, "==========\n")
+	_, _ = fmt.Fprintf(w, "Period: %s - %s\n", result.TimeRange.From.Format("02 Jan 2006"), result.TimeRange.To.Format("02 Jan 2006"))
+	_, _ = fmt.Fprintf(w, "Total: %d activities\n\n", len(result.Entries))
 
 	for _, group := range GroupByRepo(result.Entries) {
 		switch group.Source {
 		case "obsidian":
-			fmt.Fprintf(w, "Obsidian Vault\n")
-			fmt.Fprintf(w, "%s\n\n", group.Name)
+			_, _ = fmt.Fprintf(w, "Obsidian Vault\n")
+			_, _ = fmt.Fprintf(w, "%s\n\n", group.Name)
 		case "git":
-			fmt.Fprintf(w, "Git Repository: %s\n", group.Name)
-			fmt.Fprintf(w, "(%s)\n\n", group.Path)
+			_, _ = fmt.Fprintf(w, "Git Repository: %s\n", group.Name)
+			_, _ = fmt.Fprintf(w, "(%s)\n\n", group.Path)
 		case "markdown":
-			fmt.Fprintf(w, "Markdown Notes: %s\n", group.Name)
-			fmt.Fprintf(w, "(%s)\n\n", group.Path)
+			_, _ = fmt.Fprintf(w, "Markdown Notes: %s\n", group.Name)
+			_, _ = fmt.Fprintf(w, "(%s)\n\n", group.Path)
 		case "claude":
-			fmt.Fprintf(w, "Claude Sessions: %s\n", group.Name)
-			fmt.Fprintf(w, "(%s)\n\n", group.Path)
+			_, _ = fmt.Fprintf(w, "Claude Sessions: %s\n", group.Name)
+			_, _ = fmt.Fprintf(w, "(%s)\n\n", group.Path)
 		default:
-			fmt.Fprintf(w, "%s\n\n", group.Name)
+			_, _ = fmt.Fprintf(w, "%s\n\n", group.Name)
 		}
 
 		for _, entry := range group.Entries {
-			fmt.Fprintf(w, "  \u2022 %s\n", entry.Content)
+			_, _ = fmt.Fprintf(w, "  \u2022 %s\n", entry.Content)
 		}
-		fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w)
 	}
 
 	return nil

--- a/internal/recap/render_simple.go
+++ b/internal/recap/render_simple.go
@@ -1,0 +1,41 @@
+package recap
+
+import (
+	"fmt"
+	"io"
+)
+
+// RenderSimple writes a compact recap with commit messages only.
+func RenderSimple(w io.Writer, result *RecapResult) error {
+	fmt.Fprintf(w, "\n")
+	fmt.Fprintf(w, "Work Recap\n")
+	fmt.Fprintf(w, "==========\n")
+	fmt.Fprintf(w, "Period: %s - %s\n", result.TimeRange.From.Format("02 Jan 2006"), result.TimeRange.To.Format("02 Jan 2006"))
+	fmt.Fprintf(w, "Total: %d activities\n\n", len(result.Entries))
+
+	for _, group := range GroupByRepo(result.Entries) {
+		switch group.Source {
+		case "obsidian":
+			fmt.Fprintf(w, "Obsidian Vault\n")
+			fmt.Fprintf(w, "%s\n\n", group.Name)
+		case "git":
+			fmt.Fprintf(w, "Git Repository: %s\n", group.Name)
+			fmt.Fprintf(w, "(%s)\n\n", group.Path)
+		case "markdown":
+			fmt.Fprintf(w, "Markdown Notes: %s\n", group.Name)
+			fmt.Fprintf(w, "(%s)\n\n", group.Path)
+		case "claude":
+			fmt.Fprintf(w, "Claude Sessions: %s\n", group.Name)
+			fmt.Fprintf(w, "(%s)\n\n", group.Path)
+		default:
+			fmt.Fprintf(w, "%s\n\n", group.Name)
+		}
+
+		for _, entry := range group.Entries {
+			fmt.Fprintf(w, "  \u2022 %s\n", entry.Content)
+		}
+		fmt.Fprintln(w)
+	}
+
+	return nil
+}

--- a/internal/recap/result.go
+++ b/internal/recap/result.go
@@ -1,0 +1,14 @@
+package recap
+
+import (
+	"github.com/charemma/anker/internal/sources"
+	"github.com/charemma/anker/internal/timerange"
+)
+
+// RecapResult holds the collected activity data for a time period.
+// It is the data contract between collection (BuildRecap) and rendering.
+type RecapResult struct {
+	TimeRange *timerange.TimeRange
+	Timespec  string
+	Entries   []sources.Entry
+}


### PR DESCRIPTION
## Summary

- Extract source iteration, diff enrichment, and sorting into `internal/recap/collect.go` with `BuildRecap()` and `RecapResult` type
- Deduplicate the triplicated group-by-repo pattern into `GroupByRepo()` and `SourceLabel()` helpers
- Move all four renderers (simple, detailed, json, markdown) to `internal/recap/render_*.go` with `io.Writer` signatures
- Move AI orchestration (prompt/key resolution, backend dispatch) to `internal/ai/transform.go`
- Slim `cmd/recap.go` from 473 lines to ~140 (80 lines of logic + help text)
- Add actionable empty-state guidance when no sources are configured

Closes #32

## Test plan

- [x] `go build ./...` passes after each commit
- [x] `go test ./...` passes after each commit
- [x] Manual: `anker recap today --format simple` produces identical output
- [x] Manual: `anker recap today --format detailed` produces identical output
- [x] Manual: `anker recap today --format json` produces identical output
- [x] Manual: `anker recap today --format markdown` produces identical output
- [x] Manual: `anker recap today --format ai` produces identical output
- [x] Manual: `anker recap` with no sources shows new guidance message