### PR TITLE
feat(config) Add language to config for user default

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -140,15 +140,26 @@ Examples:
 			return runErr
 		}
 
-		emailChanged := false
+		configChanged := false
 		if !initYes {
-			emailChanged, runErr = initStepEmail(cfg)
+			emailChanged, runErr := initStepEmail(cfg)
 			if runErr != nil {
 				return runErr
 			}
+			if emailChanged {
+				configChanged = true
+			}
+
+			langChanged, runErr := initStepLanguage(cfg)
+			if runErr != nil {
+				return runErr
+			}
+			if langChanged {
+				configChanged = true
+			}
 		}
 
-		if emailChanged {
+		if configChanged {
 			if err := config.Save(cfg); err != nil {
 				_, _ = fmt.Fprintf(os.Stderr, "warning: could not save config: %v\n", err)
 			}
@@ -721,6 +732,38 @@ func initStepEmail(cfg *config.Config) (bool, error) {
 
 	cfg.AuthorEmail = email
 	fmt.Println(styleSuccess.Render("Git author: " + email))
+	fmt.Println()
+	return true, nil
+}
+
+// initStepLanguage handles the recap language configuration step.
+// Returns true if the language was updated and config should be saved.
+func initStepLanguage(cfg *config.Config) (bool, error) {
+	if cfg.AILanguage != "" {
+		initCheckLine("Recap language", cfg.AILanguage+" (already configured)")
+		return false, nil
+	}
+
+	initSectionHeader("Recap language")
+
+	var lang string
+	if err := huh.NewInput().
+		Title("Language for AI recaps (e.g. english, deutsch, español)").
+		Value(&lang).
+		Run(); initIsAbort(err) {
+		fmt.Println()
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	fmt.Println()
+
+	if lang == "" {
+		return false, nil
+	}
+
+	cfg.AILanguage = lang
+	fmt.Println(styleSuccess.Render("Recap language: " + lang))
 	fmt.Println()
 	return true, nil
 }

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -82,7 +82,7 @@ Examples:
 		// Resolve style: --style flag > config ai_default_style > "digest"
 		style := resolveStyle(recapStyle, cfg.AIDefaultStyle)
 
-		// Resolve language: --lang flag > config ai_language > "deutsch"
+		// Resolve language: --lang flag > config ai_language > "english"
 		lang := resolveLanguage(recapLang, cfg.AILanguage)
 
 		// Resolve timespec: explicit arg > style default
@@ -355,7 +355,7 @@ func runListStyles(w *os.File, verbose bool) error {
 	return nil
 }
 
-// resolveLanguage returns the effective output language from flag, config, or "deutsch".
+// resolveLanguage returns the effective output language from flag, config, or "english".
 func resolveLanguage(flagValue, configDefault string) string {
 	if flagValue != "" {
 		return flagValue
@@ -363,7 +363,7 @@ func resolveLanguage(flagValue, configDefault string) string {
 	if configDefault != "" {
 		return configDefault
 	}
-	return "deutsch"
+	return "english"
 }
 
 // resolveStyle returns the effective style from flag, config default, or "self".

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,6 +132,9 @@ week_start: monday
 # "api" calls an OpenAI-compatible API directly.
 # ai_backend: cli
 # ai_cli_command: claude -p            # CLI tool for ai_backend: cli
+#
+# Output language for AI recaps (full name, not ISO code; default: deutsch)
+# ai_language: deutsch
 `
 
 // Save writes the configuration to $IKNO_HOME/config.yaml or ~/.config/ikno/config.yaml.


### PR DESCRIPTION
This allows the user to set their preferred language via `init` and directly in the config file to allow non Deutsch speakers to not have to pass the `--lang` flag on every `recap`.