### PR TITLE
feat(ai): add HTTP timeouts to prevent indefinite hang on slow endpoints

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -9,7 +9,21 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
+
+// httpClient is shared by all LLM API calls. Deadlines bound connection
+// setup and the wait for response headers so a slow or hung endpoint
+// cannot tie up the CLI indefinitely. Once headers arrive, the streaming
+// body is unrestricted — legitimate long generations (e.g. a 7B model on
+// CPU taking several minutes) complete normally.
+var httpClient = &http.Client{
+	Transport: &http.Transport{
+		ResponseHeaderTimeout: 60 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
+	},
+}
 
 type Client struct {
 	BaseURL string
@@ -47,7 +61,7 @@ func (c *Client) StreamCompletion(ctx context.Context, systemPrompt, userContent
 		return err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("API request failed: %w", err)
 	}

--- a/internal/ai/client_test.go
+++ b/internal/ai/client_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBuildRequest_BasicFields(t *testing.T) {
@@ -109,6 +112,47 @@ func TestStreamCompletion_MissingBaseURL(t *testing.T) {
 	err := c.StreamCompletion(context.Background(), "prompt", "content", io.Discard)
 	if err == nil {
 		t.Fatal("expected error for missing base URL")
+	}
+}
+
+func TestStreamCompletion_HeaderTimeout(t *testing.T) {
+	// Server that accepts the connection but never sends response headers,
+	// simulating a hung or malicious endpoint. A client without a header
+	// timeout would block here indefinitely. The handler unblocks on
+	// either request-context cancel or a hard ceiling as a safety net.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(500 * time.Millisecond):
+		}
+	}))
+	// ResponseHeaderTimeout reports the error to the caller but does not
+	// actively close the socket, so httptest.Server.Close() would block
+	// on the still-active connection. CloseClientConnections releases it.
+	defer func() {
+		server.CloseClientConnections()
+		server.Close()
+	}()
+
+	origClient := httpClient
+	httpClient = &http.Client{
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: 100 * time.Millisecond,
+		},
+	}
+	defer func() { httpClient = origClient }()
+
+	c := &Client{BaseURL: server.URL + "/v1/", APIKey: "x", Model: "test"}
+
+	start := time.Now()
+	err := c.StreamCompletion(context.Background(), "prompt", "content", io.Discard)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if elapsed > time.Second {
+		t.Errorf("expected fail within ~100ms header timeout, got %v", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

The AI client currently uses `http.DefaultClient` with no timeouts. A slow or unreachable endpoint that accepts the TCP connection but never sends response headers will hang `ikno` indefinitely. This is especially easy to hit with self-hosted backends (Ollama, LocalAI, vLLM) where the endpoint is user-configured and could be misconfigured, down, or behind a stalled reverse proxy.

This PR adds transport-level deadlines that bound connection setup and the wait for response headers, without interfering with legitimate long generations.

## Why not a whole-request timeout?

The existing design streams tokens as they arrive. Setting `http.Client.Timeout` would kill legitimate long completions — a 7B model on CPU can easily take several minutes to finish. `Transport.ResponseHeaderTimeout` is the right primitive: it bounds only the wait for headers. Once the server starts streaming, the body is unrestricted and long generations complete normally.

## Changes

- Package-level `httpClient` in `internal/ai/client.go`:
  - `ResponseHeaderTimeout: 60 * time.Second`
  - `TLSHandshakeTimeout: 10 * time.Second`
  - `IdleConnTimeout: 30 * time.Second`
- `StreamCompletion` switches from `http.DefaultClient.Do(req)` to `httpClient.Do(req)`.
- New test `TestStreamCompletion_HeaderTimeout` spins up an `httptest.Server` that accepts the connection but never responds, and asserts the client errors out within the configured window (passes in ~0.5s under a 100ms test override).

## Backwards compatibility

No API or config changes. Existing behavior for healthy endpoints is unchanged. The 60s header timeout is far longer than any legitimate backend takes to begin streaming.

## Test plan

- [x] `go test ./internal/ai/` — all 13 tests pass locally (0.65s total)
- [x] Built from branch and ran a real recap against a local Ollama (`mistral:7b`, 3-minute generation) — completes normally, timeouts only trip on hung endpoints
- [x] No diff in the rest of `internal/ai/` since `v0.3.2` confirmed — patch is minimal and contained

## Context

Found during a source audit before installing `ikno` on a new machine. Flagged as the only remaining operational-reliability gap in an otherwise clean codebase. Happy to iterate on timeout values or split this into two commits if preferred.