### PR TITLE
fix(config): complete language config follow-up fixes

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -758,6 +758,9 @@ func initStepLanguage(cfg *config.Config) (bool, error) {
 	}
 	fmt.Println()
 
+	// Trim whitespace from input.
+	lang = strings.TrimSpace(lang)
+
 	if lang == "" {
 		return false, nil
 	}

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -355,7 +355,7 @@ func runListStyles(w *os.File, verbose bool) error {
 	return nil
 }
 
-// resolveLanguage returns the effective output language from flag, config, or "english".
+// resolveLanguage returns the effective output language from flag, config, or "deutsch".
 func resolveLanguage(flagValue, configDefault string) string {
 	if flagValue != "" {
 		return flagValue
@@ -363,7 +363,7 @@ func resolveLanguage(flagValue, configDefault string) string {
 	if configDefault != "" {
 		return configDefault
 	}
-	return "english"
+	return "deutsch"
 }
 
 // resolveStyle returns the effective style from flag, config default, or "self".

--- a/cmd/recap_test.go
+++ b/cmd/recap_test.go
@@ -2,6 +2,50 @@ package cmd
 
 import "testing"
 
+func TestResolveLanguage(t *testing.T) {
+	tests := []struct {
+		name          string
+		flagValue     string
+		configDefault string
+		want          string
+	}{
+		{
+			name:          "flag takes precedence",
+			flagValue:     "english",
+			configDefault: "deutsch",
+			want:          "english",
+		},
+		{
+			name:          "config used when flag empty",
+			flagValue:     "",
+			configDefault: "greek",
+			want:          "greek",
+		},
+		{
+			name:          "default when both empty",
+			flagValue:     "",
+			configDefault: "",
+			want:          "deutsch",
+		},
+		{
+			name:          "flag overrides empty config",
+			flagValue:     "spanish",
+			configDefault: "",
+			want:          "spanish",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveLanguage(tt.flagValue, tt.configDefault)
+			if got != tt.want {
+				t.Errorf("resolveLanguage(%q, %q) = %q, want %q",
+					tt.flagValue, tt.configDefault, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseTemplateFile(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,7 +164,9 @@ week_start: monday
 # ai_backend: cli
 # ai_cli_command: claude -p            # CLI tool for ai_backend: cli
 #
-# Output language for AI recaps (full name, not ISO code; default: deutsch)
+# Output language for AI summaries (default: deutsch)
+# Use full language names: deutsch, english, greek, etc.
+# Overridable with --lang flag on each recap command.
 # ai_language: deutsch
 `
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ func DefaultConfig() *Config {
 		AIModel:       "claude-sonnet-4-20250514",
 		AIBackend:     "cli",
 		AICLICommand:  "claude -p",
+		AILanguage:    "deutsch", // default output language for AI summaries
 	}
 }
 


### PR DESCRIPTION
Resolves #68

This PR addresses all three follow-up items from issue #68:

## Changes

1. **Fixed inconsistent default**: `resolveLanguage()` now returns `"deutsch"` as the final fallback, matching the value set in `DefaultConfig()`. Previously it returned `"english"`, which would override the config default for users with existing config files.

2. **Added test coverage**: New `TestResolveLanguage()` test verifies the precedence chain works correctly: flag > config > default.

3. **Input sanitization**: `initStepLanguage()` now trims whitespace from user input before assigning to config.

4. **Improved documentation**: Updated config template comment to be more descriptive about the `ai_language` setting.

## Testing

All tests pass:
```
go test ./...
```

The new `TestResolveLanguage()` test validates all four scenarios:
- Flag takes precedence over config
- Config used when flag empty
- Default applied when both empty
- Flag overrides empty config