### PR TITLE
fix(config): follow-up fixes for language config

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -758,6 +758,9 @@ func initStepLanguage(cfg *config.Config) (bool, error) {
 	}
 	fmt.Println()
 
+	// Trim whitespace from input.
+	lang = strings.TrimSpace(lang)
+
 	if lang == "" {
 		return false, nil
 	}

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -355,7 +355,7 @@ func runListStyles(w *os.File, verbose bool) error {
 	return nil
 }
 
-// resolveLanguage returns the effective output language from flag, config, or "english".
+// resolveLanguage returns the effective output language from flag, config, or "deutsch".
 func resolveLanguage(flagValue, configDefault string) string {
 	if flagValue != "" {
 		return flagValue
@@ -363,7 +363,7 @@ func resolveLanguage(flagValue, configDefault string) string {
 	if configDefault != "" {
 		return configDefault
 	}
-	return "english"
+	return "deutsch"
 }
 
 // resolveStyle returns the effective style from flag, config default, or "self".

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -355,7 +355,7 @@ func runListStyles(w *os.File, verbose bool) error {
 	return nil
 }
 
-// resolveLanguage returns the effective output language from flag, config, or "deutsch".
+// resolveLanguage returns the effective output language from flag, config, or "english".
 func resolveLanguage(flagValue, configDefault string) string {
 	if flagValue != "" {
 		return flagValue

--- a/cmd/recap.go
+++ b/cmd/recap.go
@@ -363,7 +363,7 @@ func resolveLanguage(flagValue, configDefault string) string {
 	if configDefault != "" {
 		return configDefault
 	}
-	return "deutsch"
+	return "english"
 }
 
 // resolveStyle returns the effective style from flag, config default, or "self".

--- a/cmd/recap_test.go
+++ b/cmd/recap_test.go
@@ -25,7 +25,7 @@ func TestResolveLanguage(t *testing.T) {
 			name:          "default when both empty",
 			flagValue:     "",
 			configDefault: "",
-			want:          "deutsch",
+			want:          "english",
 		},
 		{
 			name:          "flag overrides empty config",

--- a/cmd/recap_test.go
+++ b/cmd/recap_test.go
@@ -2,6 +2,50 @@ package cmd
 
 import "testing"
 
+func TestResolveLanguage(t *testing.T) {
+	tests := []struct {
+		name          string
+		flagValue     string
+		configDefault string
+		want          string
+	}{
+		{
+			name:          "flag takes precedence",
+			flagValue:     "english",
+			configDefault: "deutsch",
+			want:          "english",
+		},
+		{
+			name:          "config used when flag empty",
+			flagValue:     "",
+			configDefault: "greek",
+			want:          "greek",
+		},
+		{
+			name:          "default when both empty",
+			flagValue:     "",
+			configDefault: "",
+			want:          "deutsch",
+		},
+		{
+			name:          "flag overrides empty config",
+			flagValue:     "spanish",
+			configDefault: "",
+			want:          "spanish",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveLanguage(tt.flagValue, tt.configDefault)
+			if got != tt.want {
+				t.Errorf("resolveLanguage(%q, %q) = %q, want %q",
+					tt.flagValue, tt.configDefault, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseTemplateFile(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,7 +164,9 @@ week_start: monday
 # ai_backend: cli
 # ai_cli_command: claude -p            # CLI tool for ai_backend: cli
 #
-# Output language for AI recaps (full name, not ISO code; default: deutsch)
+# Output language for AI summaries (default: deutsch)
+# Use full language names: deutsch, english, greek, etc.
+# Overridable with --lang flag on each recap command.
 # ai_language: deutsch
 `
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ func DefaultConfig() *Config {
 		AIModel:       "claude-sonnet-4-20250514",
 		AIBackend:     "cli",
 		AICLICommand:  "claude -p",
+		AILanguage:    "deutsch", // default output language for AI summaries
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,7 @@ func DefaultConfig() *Config {
 		AIModel:       "claude-sonnet-4-20250514",
 		AIBackend:     "cli",
 		AICLICommand:  "claude -p",
-		AILanguage:    "deutsch", // default output language for AI summaries
+		AILanguage:    "english", // default output language for AI summaries
 	}
 }
 
@@ -164,10 +164,10 @@ week_start: monday
 # ai_backend: cli
 # ai_cli_command: claude -p            # CLI tool for ai_backend: cli
 #
-# Output language for AI summaries (default: deutsch)
+# Output language for AI summaries (default: english)
 # Use full language names: deutsch, english, greek, etc.
 # Overridable with --lang flag on each recap command.
-# ai_language: deutsch
+# ai_language: english
 `
 
 // Save writes the configuration to $IKNO_HOME/config.yaml or ~/.config/ikno/config.yaml.


### PR DESCRIPTION
## Summary

Fixes all items from issue #68 - follow-up fixes after merging PR #56 (language config feature).

## Changes

- Fixed config template comment to say `default: english` (was incorrectly `default: deutsch`)
- Fixed config template example to use `ai_language: english` (was `ai_language: deutsch`)
- Added test coverage for `resolveLanguage()` to verify flag > config > default precedence
- Added whitespace trimming on language input in `initStepLanguage()` with `strings.TrimSpace`
- Fixed comment in `resolveLanguage()` function to correctly say `"english"` instead of `"deutsch"`

## Test Plan

- [x] All existing tests pass
- [x] New test `TestResolveLanguage` verifies precedence chain (flag > config > default "english")
- [x] Manual testing: `anker init` wizard accepts and trims language input correctly
- [x] Config template comments and examples now match the actual default behavior

Closes #68